### PR TITLE
Fix token decimals

### DIFF
--- a/uniswap-xdai.tokenlist.json
+++ b/uniswap-xdai.tokenlist.json
@@ -89,7 +89,7 @@
       "name": "JOON on xDai",
       "address": "0x5fE9885226677F3Eb5C9ad8aB6c421B4EA38535d",
       "symbol": "JOON",
-      "decimals": 18,
+      "decimals": 4,
       "chainId": 100,
       "logoURI": "https://assets.coingecko.com/coins/images/12595/small/logo.png"
     },

--- a/uniswap-xdai.tokenlist.json
+++ b/uniswap-xdai.tokenlist.json
@@ -209,7 +209,7 @@
       "name": "Tether on xDai",
       "address": "0x4ECaBa5870353805a9F068101A40E0f32ed605C6",
       "symbol": "USDT",
-      "decimals": 18,
+      "decimals": 6,
       "chainId": 100,
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
     },


### PR DESCRIPTION
Tether uses 6 decimals, not 18. And JOON uses 4 decimals, not 18.