### PR TITLE
Fix DATA address

### DIFF
--- a/src/tokens/xdai.json
+++ b/src/tokens/xdai.json
@@ -791,8 +791,8 @@
     "logoURI": "https://etherscan.io/token/images/soratoken_32.png"
   },
   {
-    "name": "Streamr DATAcoin on xDai",
-    "address": "0x796879025A627d34042E3eDd2E239E75ba4445e6",
+    "name": "Streamr DATA on xDai",
+    "address": "0xE4a2620edE1058D61BEe5F45F6414314fdf10548",
     "symbol": "DATA",
     "decimals": 18,
     "chainId": 100,


### PR DESCRIPTION
Hi! The address of the correct DATA token that's nowadays being bridged by OmniBridge and used on xDai chain is `0xE4a2620edE1058D61BEe5F45F6414314fdf10548`. The previous entry for DATA was to an abandoned instance of the token autogenerated by the OmniBridge. That token instance isn't being used and is not supported by the Streamr ecosystem dapps deployed on xDai.