### PR TITLE
Fix Cheemscoin Logo

### DIFF
--- a/src/tokens/xdai.json
+++ b/src/tokens/xdai.json
@@ -508,7 +508,7 @@
     "symbol": "CHEEMS",
     "decimals": 18,
     "chainId": 100,
-    "logoURI": "https://kowasaur.github.io/cheemscoin/cheemscoin.png"
+    "logoURI": "https://cheemsco.in/cheemscoinSmall.png"
   },
   {
     "name": "0x Protocol Token on xDai",


### PR DESCRIPTION
The current url doesn't work so I changed it to https://cheemsco.in/cheemscoinSmall.png