### PR TITLE
DATA token migration

### DIFF
--- a/src/tokens/xdai.json
+++ b/src/tokens/xdai.json
@@ -785,11 +785,11 @@
     },
     {
         "name": "Streamr DATA on xDai",
-        "address": "0xE4a2620edE1058D61BEe5F45F6414314fdf10548",
+        "address": "0x256eb8a51f382650B2A1e946b8811953640ee47D",
         "symbol": "DATA",
         "decimals": 18,
         "chainId": 100,
-        "logoURI": "https://etherscan.io/token/images/streamr2_28.png"
+        "logoURI": "https://streamr-public.s3.amazonaws.com/streamr-new-token-mark-256px.png"
     },
     {
         "name": "SwissBorg Token on xDai",


### PR DESCRIPTION
Streamr DATA token has been migrated to a new contract, both in mainnet and in xdai.

See the official token migration page: https://streamr.network/token-migration

Logo changed a bit, too. Please check that it's correctly formatted for 1Hive's needs. Let us know if you need it in some other format. Thanks!