### PR TITLE
Re-enabling uniswap enforced schema

### DIFF
--- a/src/tokens/gnosis.json
+++ b/src/tokens/gnosis.json
@@ -1728,7 +1728,7 @@
     "logoURI": "https://raw.githubusercontent.com/1Hive/default-token-list/master/src/assets/gnosis/0xb17d999e840e0c1b157ca5ab8039bd958b5fa317/logo.png"
   },
   {
-    "name": "Wrapped liquid staked Ether 2.0 from Mainnet",
+    "name": "Wrapped liquid staked Ether 2.0",
     "address": "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
     "symbol": "wstETH",
     "decimals": 18,

--- a/test/tokenlist.schema.json
+++ b/test/tokenlist.schema.json
@@ -65,7 +65,7 @@
         "type": "string",
         "description": "The name of a token extension property",
         "minLength": 0,
-        "maxLength": 50,
+        "maxLength": 40,
         "pattern": "^[\\w]+$",
         "examples": [
           "color",
@@ -232,7 +232,7 @@
             "type": "string",
             "description": "The name of the token",
             "minLength": 0,
-            "maxLength": 50,
+            "maxLength": 40,
             "anyOf": [
               {
                 "const": ""


### PR DESCRIPTION
Adjust 'Wrapped liquid staked Ether 2.0' to be shorter than 40 characters in name, and restore Uniswap schema